### PR TITLE
chore(db)!: cleanup database tables and functions

### DIFF
--- a/supabase/migrations/20230828125345_remove_parsed_document_sections_large_and_functions.sql
+++ b/supabase/migrations/20230828125345_remove_parsed_document_sections_large_and_functions.sql
@@ -33,3 +33,10 @@ BEGIN
 			LIMIT match_count;
 END;
 $function$
+
+-- EXAMPLE for creating index on the "embeddings" column
+-- Attention: Creating index only makes sense after the table is populated with data
+-- Parameters according to https://github.com/pgvector/pgvector 
+-- CREATE INDEX ON parsed_document_sections_large_clone USING ivfflat (embedding vector_l2_ops) WITH (lists = 48);
+-- CREATE INDEX ON parsed_document_sections_large_clone USING ivfflat (embedding vector_ip_ops) WITH (lists = 48);
+-- CREATE INDEX ON parsed_document_sections_large_clone USING ivfflat (embedding vector_cosine_ops) WITH (lists = 48);

--- a/supabase/migrations/20230828125345_remove_parsed_document_sections_large_and_functions.sql
+++ b/supabase/migrations/20230828125345_remove_parsed_document_sections_large_and_functions.sql
@@ -1,0 +1,35 @@
+DROP TABLE parsed_document_sections_large;
+DROP FUNCTION match_parsed_dokument_sections_large;
+DROP FUNCTION match_parsed_dokument_sections;
+
+CREATE OR REPLACE FUNCTION public.match_parsed_dokument_sections(embedding vector, match_threshold double precision, match_count integer, min_content_length integer, num_probes integer)
+ RETURNS TABLE(id bigint, parsed_document_id bigint, heading text, content text, similarity double precision)
+ LANGUAGE plpgsql
+AS $function$
+	#variable_conflict use_variable
+BEGIN
+	SET LOCAL ivfflat.probes = num_probes;
+	RETURN query
+	SELECT
+		parsed_document_sections.id,
+		parsed_document_sections.parsed_document_id,
+		parsed_document_sections.heading,
+		parsed_document_sections.content,
+		(parsed_document_sections.embedding <#> embedding) * -1 as similarity
+		FROM
+			parsed_document_sections
+			-- We only care about sections that have a useful amount of content
+		WHERE
+			length(parsed_document_sections.content) >= min_content_length
+			-- The dot product is negative because of a Postgres limitation, so we negate it
+			and(parsed_document_sections.embedding <#> embedding) * -1 > match_threshold
+				-- OpenAI embeddings are normalized to length 1, so
+				-- cosine similarity and dot product will produce the same results.
+				-- Using dot product which can be computed slightly faster.
+				--
+				-- For the different syntaxes, see https://github.com/pgvector/pgvector
+			ORDER BY
+				parsed_document_sections.embedding <#> embedding
+			LIMIT match_count;
+END;
+$function$


### PR DESCRIPTION
- Drop the `_large` tables
- Drop the `_large` function
- Update the function to pass the `probes` parameter which we can use to tweak the "exactness" of the vector similarity search on the indexed table